### PR TITLE
Adding syntax for maximum attempts and custom feedback

### DIFF
--- a/assets/mcqx.js
+++ b/assets/mcqx.js
@@ -7,10 +7,14 @@ require(["gitbook", "jquery"], function(gitbook, $) {
         this.title = input.title;
         this.option = input.option;
 
+        this.attempts = 0;
+
         if (input.hint) this.hint = input.hint;
         if (input.count) this.count = input.count;
         if (input.random) this.random = input.random;
         if (input.message) this.message = input.message;
+        if (input.incorrect) this.incorrect = input.incorrect;
+        if (input.maxattempts) this.maxattempts = input.maxattempts;
     }
 
     MultipleChoice.prototype.checkAns = function(input) {
@@ -65,6 +69,16 @@ require(["gitbook", "jquery"], function(gitbook, $) {
                     $mcqBox.find('.MCQdescription').text(question.message).show(speed);
             };
 
+            //incorrect answer handling when max attempts are specified.
+            var incorrectAnswer = function(animation) {
+                $mcqBox.find('.submitMCQ, .hintMCQ').attr('disabled', true);
+                $mcqBox.find('input[name=' + question.qid + '_group]').attr('disabled', true);
+
+                var speed = animation ? 'slow' : null;
+
+                $mcqBox.find('.MCQmessage').text((question.incorrect) ? question.incorrect : "Wrong answer.").show(speed);
+            };
+
             // prepare options  ---------------------------
             var optionsToShow = [];
             if (question.random || question.count < question.option.length) {
@@ -98,7 +112,14 @@ require(["gitbook", "jquery"], function(gitbook, $) {
                     }); //planting a cookie
                     correctAnswer(true);
                 } else {
-                    $mcqBox.find('.MCQmessage').text("Wrong answer, try again.").show('slow').delay(1000).hide('slow');
+                  //if incorrect, increase question attempts counter.
+                  question.attempts++;
+                  //if max attempts reached, mark answer as incorrect.
+                  if(question.attempts >= question.maxattempts){
+                    incorrectAnswer(true);
+                  } else {
+                  //if incorrect, display custom message (or default if one is not specified)
+                  $mcqBox.find('.MCQmessage').text((question.incorrect) ? question.incorrect : "Wrong answer, try again.").show('slow').delay(1000).hide('slow');
                 }
             });
 

--- a/assets/mcqx.js
+++ b/assets/mcqx.js
@@ -120,6 +120,7 @@ require(["gitbook", "jquery"], function(gitbook, $) {
                   } else {
                   //if incorrect, display custom message (or default if one is not specified)
                   $mcqBox.find('.MCQmessage').text((question.incorrect) ? question.incorrect : "Wrong answer, try again.").show('slow').delay(1000).hide('slow');
+                  }
                 }
             });
 

--- a/index.js
+++ b/index.js
@@ -22,11 +22,12 @@ module.exports = {
 
     blocks: {
         mcq: {
-            blocks: ['title', 'o1', 'o2', 'o3', 'o4', 'o5', 'o6', 'o7', 'o8', 'hint', 'message'],
+            blocks: ['title', 'o1', 'o2', 'o3', 'o4', 'o5', 'o6', 'o7', 'o8', 'hint', 'message', 'incorrect'],
             process: function(blk) {
 
                 var question = {
                     ans: blk.kwargs.ans.trim(),
+                    maxattempts: blk.kwargs.maxattempts ? blk.kwargs.maxattempts : false,
                     random: blk.kwargs.random || false,
                     target: blk.kwargs.target ? blk.kwargs.target.trim() : false,
                     option: []


### PR DESCRIPTION
I have a request from a user to add two functions that aren't present in the plugin:

- Allow the course developer to specify a maximum number of attempts for a question.
- Allow the developer to define a custom feedback message when the student submits an incorrect message.

Let me know if you are interesting in incorporating this into the main project!  I have already created code that implements this functionality, but I can also work on updating the documentation, code generator, etc. if needed.